### PR TITLE
feat: add dry-validation schema

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'tmp/**/*'
     - 'config/**/*'
     - 'spec/rails_helper.rb'
+    - 'Guardfile'
 
 Style/StringLiterals:
   EnforcedStyle: 'double_quotes'

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem "pundit"
 
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
+gem "dry-validation"
 gem "jsonapi-serializer"
 gem "rswag"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,38 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
     digest (3.1.0)
+    dry-configurable (1.0.1)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-core (1.0.0)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-inflector (1.0.0)
+    dry-initializer (3.1.1)
+    dry-logic (1.5.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
+    dry-schema (1.13.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-logic (>= 1.5, < 2)
+      dry-types (>= 1.7, < 2)
+      zeitwerk (~> 2.6)
+    dry-types (1.7.1)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
+    dry-validation (1.10.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      dry-initializer (~> 3.0)
+      dry-schema (>= 1.12, < 2)
+      zeitwerk (~> 2.6)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -298,6 +330,7 @@ DEPENDENCIES
   database_cleaner
   debug
   devise
+  dry-validation
   factory_bot_rails
   faker
   guard-rspec

--- a/app/schemas/application_schema.rb
+++ b/app/schemas/application_schema.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class ApplicationSchema < Dry::Validation::Contract
+  class ValidationSchemaError < StandardError; end
+
+  def self.call!(attributes)
+    new.call(attributes).then do |result|
+      raise ValidationSchemaError, result.errors.to_h if result.errors.present?
+
+      result.to_h
+    end
+  end
+end

--- a/app/schemas/dog/create/schema.rb
+++ b/app/schemas/dog/create/schema.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class Dog
+  module Create
+    class Schema < ApplicationSchema
+      json do
+        required(:name).filled(:string)
+        optional(:breed).filled(:string)
+        optional(:weight).filled(:integer)
+        optional(:age).filled(:integer)
+        optional(:gender).filled(:string)
+        optional(:fussiness_level).filled(:string)
+        optional(:health_issues).filled(:array).each(:string)
+        optional(:activity_level).filled(:string)
+        optional(:allergies).filled(:array).each(:string)
+        optional(:kcal_per_day).filled(:integer)
+        optional(:food_portion_in_grams).filled(:integer)
+      end
+    end
+  end
+end


### PR DESCRIPTION
- also added a ApplicationSchema now we can use the schemas as follows: `Dog::Create::Schema.call!(attributes)` this will raise an error if the attributes are invalid and return the attributes as a hash if they are valid